### PR TITLE
Handle workflow failure gracefully

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Merge Schedule
+name: New Merge Schedule
 description: "merge pull requests on a scheduled day"
 branding:
   icon: "git-merge"

--- a/dist/index.js
+++ b/dist/index.js
@@ -190,37 +190,64 @@ async function handleSchedule() {
   }
 
   for await (const pullRequest of duePullRequests) {
-    await octokit.pulls.merge({
-      owner,
-      repo,
-      pull_number: pullRequest.number,
-      merge_method: mergeMethod,
-    });
+    try {
+      await octokit.pulls.merge({
+        owner,
+        repo,
+        pull_number: pullRequest.number,
+        merge_method: mergeMethod,
+      });
 
-    // find check runs by the Merge schedule action
-    const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
-      owner,
-      repo,
-      ref: pullRequest.ref,
-    });
+      // find check runs by the Merge schedule action
+      const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
+        owner,
+        repo,
+        ref: pullRequest.ref,
+      });
 
-    const checkRun = checkRuns.pop();
-    if (!checkRun) continue;
+      const checkRun = checkRuns.pop();
+      if (!checkRun) continue;
 
-    await octokit.checks.update({
-      check_run_id: checkRun.id,
-      owner,
-      repo,
-      name: "Merge Schedule",
-      head_sha: pullRequest.headSha,
-      conclusion: "success",
-      output: {
-        title: `Scheduled on ${pullRequest.scheduledDate}`,
-        summary: "Merged successfully",
-      },
-    });
+      await octokit.checks.update({
+        check_run_id: checkRun.id,
+        owner,
+        repo,
+        name: "Merge Schedule",
+        head_sha: pullRequest.headSha,
+        conclusion: "success",
+        output: {
+          title: `Scheduled on ${pullRequest.scheduledDate}`,
+          summary: "Merged successfully",
+        },
+      });
 
-    core.info(`${pullRequest.html_url} merged`);
+      core.info(`${pullRequest.html_url} merged`);
+    } catch (err) {
+      core.info(`Error is : ${err}`);
+      core.info(`${pullRequest.html_url} is having some issue`);
+      // find check runs by the Merge schedule action
+      const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
+        owner,
+        repo,
+        ref: pullRequest.ref,
+      });
+
+      const checkRun = checkRuns.pop();
+      if (!checkRun) continue;
+
+      await octokit.checks.update({
+        check_run_id: checkRun.id,
+        owner,
+        repo,
+        name: "Merge Schedule",
+        head_sha: pullRequest.headSha,
+        conclusion: "failure",
+        output: {
+          title: `Scheduled on ${pullRequest.scheduledDate}`,
+          summary: "Failed to merge",
+        },
+      });
+    }
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -223,8 +223,8 @@ async function handleSchedule() {
 
       core.info(`${pullRequest.html_url} merged`);
     } catch (err) {
-      core.info(`Error is : ${err}`);
-      core.info(`${pullRequest.html_url} is having some issue`);
+      core.info(`Unable to merge ${pullRequest.html_url}`);
+      core.info(`The Error is : ${err}`);
       // find check runs by the Merge schedule action
       const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
         owner,

--- a/lib/handle_schedule.js
+++ b/lib/handle_schedule.js
@@ -54,37 +54,64 @@ async function handleSchedule() {
   }
 
   for await (const pullRequest of duePullRequests) {
-    await octokit.pulls.merge({
-      owner,
-      repo,
-      pull_number: pullRequest.number,
-      merge_method: mergeMethod,
-    });
+    try {
+      await octokit.pulls.merge({
+        owner,
+        repo,
+        pull_number: pullRequest.number,
+        merge_method: mergeMethod,
+      });
 
-    // find check runs by the Merge schedule action
-    const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
-      owner,
-      repo,
-      ref: pullRequest.ref,
-    });
+      // find check runs by the Merge schedule action
+      const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
+        owner,
+        repo,
+        ref: pullRequest.ref,
+      });
 
-    const checkRun = checkRuns.pop();
-    if (!checkRun) continue;
+      const checkRun = checkRuns.pop();
+      if (!checkRun) continue;
 
-    await octokit.checks.update({
-      check_run_id: checkRun.id,
-      owner,
-      repo,
-      name: "Merge Schedule",
-      head_sha: pullRequest.headSha,
-      conclusion: "success",
-      output: {
-        title: `Scheduled on ${pullRequest.scheduledDate}`,
-        summary: "Merged successfully",
-      },
-    });
+      await octokit.checks.update({
+        check_run_id: checkRun.id,
+        owner,
+        repo,
+        name: "Merge Schedule",
+        head_sha: pullRequest.headSha,
+        conclusion: "success",
+        output: {
+          title: `Scheduled on ${pullRequest.scheduledDate}`,
+          summary: "Merged successfully",
+        },
+      });
 
-    core.info(`${pullRequest.html_url} merged`);
+      core.info(`${pullRequest.html_url} merged`);
+    } catch (err) {
+      core.info(`Error is : ${err}`);
+      core.info(`${pullRequest.html_url} is having some issue`);
+      // find check runs by the Merge schedule action
+      const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
+        owner,
+        repo,
+        ref: pullRequest.ref,
+      });
+
+      const checkRun = checkRuns.pop();
+      if (!checkRun) continue;
+
+      await octokit.checks.update({
+        check_run_id: checkRun.id,
+        owner,
+        repo,
+        name: "Merge Schedule",
+        head_sha: pullRequest.headSha,
+        conclusion: "failure",
+        output: {
+          title: `Scheduled on ${pullRequest.scheduledDate}`,
+          summary: "Failed to merge",
+        },
+      });
+    }
   }
 }
 

--- a/lib/handle_schedule.js
+++ b/lib/handle_schedule.js
@@ -87,8 +87,8 @@ async function handleSchedule() {
 
       core.info(`${pullRequest.html_url} merged`);
     } catch (err) {
-      core.info(`Error is : ${err}`);
-      core.info(`${pullRequest.html_url} is having some issue`);
+      core.info(`Unable to merge ${pullRequest.html_url}`);
+      core.info(`The Error is : ${err}`);
       // find check runs by the Merge schedule action
       const checkRuns = await octokit.paginate(octokit.checks.listForRef, {
         owner,


### PR DESCRIPTION
Added try catch block to handle workflow failure gracefully.

1. Added try catch
2. Display error as well as PR link in console

Issue: https://github.com/Pay-Baymax/sre-pr-merge-schedule-test/issues/117